### PR TITLE
bug fix to get IMEI on Android 9 (API 28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,6 @@
 
 ## 0.0.4
 * Bug Fixes.
+
+## 0.0.4
+* Bug Fixe to get IMEI on Android 9 (API 28)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A flutter plugin to get device information such as device IMEI number, model nam
 Add following dependency in pubspec.yaml file:
 
 ```bash
-device_information:^0.0.4
+device_information:^0.0.5
 ```
 Install by running:
 
@@ -45,9 +45,10 @@ Although in iOS there is no need to specify permissions.
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
 ## Developer Team:
-Hina Hussain & her team members (Kamran Khan, Abdul Sattar, Faiza Farooqui) :smile: :tada:
+Jean-Louis Le Strat :smile: :tada:
 
 ## Follow me
+Fork of Hina Hussain & her team members (Kamran Khan, Abdul Sattar, Faiza Farooqui) :smile: :tada:
 https://hina-hussain-developer.medium.com/creating-publisher-account-on-the-pub-dev-cf86b91cd2f
 https://hinahussaindev.blogspot.com/2021/05/creating-publisher-account-on-pubdev.html
 

--- a/android/src/main/java/co/creativemind/device_information/DeviceInformationPlugin.java
+++ b/android/src/main/java/co/creativemind/device_information/DeviceInformationPlugin.java
@@ -95,7 +95,7 @@ public class DeviceInformationPlugin implements FlutterPlugin, MethodCallHandler
     if (ContextCompat.checkSelfPermission(activity, Manifest.permission.READ_PHONE_STATE) != PackageManager.PERMISSION_GRANTED) {
       return Manifest.permission.READ_PHONE_STATE;
     }else{
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
         imeiNumber = getDeviceUniqueID();
 
       }else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_information
 description: A flutter plugin to get device information such as device IMEI number,model name,API level,CPU Type,Product Name etc for both android & iOS.
-version: 0.0.4
-homepage: https://github.com/Hina-Hussain/DeviceInformationPlugin
+version: 0.0.5
+homepage: https://github.com/jlestrat/DeviceInformationPlugin.git
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
The function "imeiNumber = telephonyManager.getImei();" working on Android 9.
I modify condition to get IMEI on Android 9 with this function.